### PR TITLE
Updated Mappings to 2013.03 Amazon Linux AMI IDs

### DIFF
--- a/asgard.template
+++ b/asgard.template
@@ -42,6 +42,7 @@
                                 "rpm -Uvhf /home/ec2-user/ruby-1.9.3p0-2.amzn1.x86_64.rpm\n",
                                 "gem install chef --no-ri --no-rdoc\n",
                                 "git clone git@github.com:ktgit/asgard-in-the-cloud.git /home/ec2-user/asgard-in-the-cloud\n",
+                                "git clone https://github.com/fnichol/chef-user.git /home/ec2-user/asgard-in-the-cloud/chef/cookbooks/user\n",
                                 {
                                     "Fn::Join": [
                                         "",

--- a/asgard.template
+++ b/asgard.template
@@ -1,5 +1,5 @@
 {
-    "Description" : "Asgard in the Cloud, by Stelligent. Deploys an Asgard application to an EC2 instance.",
+    "Description" : "A Knowledge Tree Asgard Server. This configuration deploys an Asgard application to an EC2 instance.",
 
     "Resources": {
         "IPAddress": {
@@ -41,7 +41,7 @@
                                 "wget https://s3.amazonaws.com/stelligent-blog/asgard/ruby-1.9.3p0-2.amzn1.x86_64.rpm -O /home/ec2-user/ruby-1.9.3p0-2.amzn1.x86_64.rpm\n",
                                 "rpm -Uvhf /home/ec2-user/ruby-1.9.3p0-2.amzn1.x86_64.rpm\n",
                                 "gem install chef --no-ri --no-rdoc\n",
-                                "git clone https://github.com/stelligent/asgard-in-the-cloud.git /home/ec2-user/asgard-in-the-cloud\n",
+                                "git clone git@github.com:ktgit/asgard-in-the-cloud.git /home/ec2-user/asgard-in-the-cloud\n",
                                 {
                                     "Fn::Join": [
                                         "",

--- a/asgard.template
+++ b/asgard.template
@@ -54,11 +54,11 @@
                                             {
                                                 "Ref": "Username"
                                             },
-                                            "/g' > /home/ec2-user/asgard-in-the-cloud/solo.js\n"
+                                            "/g' > /home/ec2-user/asgard-in-the-cloud/solo.json\n"
                                         ]
                                     ]
                                 },
-                                "chef-solo -c /home/ec2-user/asgard-in-the-cloud/solo.rb -j /home/ec2-user/asgard-in-the-cloud/solo.js -l debug\n",
+                                "chef-solo -c /home/ec2-user/asgard-in-the-cloud/solo.rb -j /home/ec2-user/asgard-in-the-cloud/solo.json -l debug\n",
                                 "curl -X PUT -H 'Content-Type:' --data-binary '{\"Status\" : \"SUCCESS\",",
                                    "\"Reason\" : \"The application is ready\",",
                                    "\"UniqueId\" : \"asgard\",",

--- a/asgard.template
+++ b/asgard.template
@@ -41,7 +41,7 @@
                                 "wget https://s3.amazonaws.com/stelligent-blog/asgard/ruby-1.9.3p0-2.amzn1.x86_64.rpm -O /home/ec2-user/ruby-1.9.3p0-2.amzn1.x86_64.rpm\n",
                                 "rpm -Uvhf /home/ec2-user/ruby-1.9.3p0-2.amzn1.x86_64.rpm\n",
                                 "gem install chef --no-ri --no-rdoc\n",
-                                "git clone git@github.com:ktgit/asgard-in-the-cloud.git /home/ec2-user/asgard-in-the-cloud\n",
+                                "git clone https://github.com/ktgit/asgard-in-the-cloud.git /home/ec2-user/asgard-in-the-cloud\n",
                                 "git clone https://github.com/fnichol/chef-user.git /home/ec2-user/asgard-in-the-cloud/chef/cookbooks/user\n",
                                 {
                                     "Fn::Join": [

--- a/asgard.template
+++ b/asgard.template
@@ -117,25 +117,25 @@
     "Mappings": {
         "RegionMap": {
             "us-east-1": {
-                "AMI": "ami-1624987f"
+                "AMI": "ami-05355a6c"
             },
             "us-west-1": {
-                "AMI": "ami-1bf9de5e"
+                "AMI": "ami-3ffed17a"
             },
             "us-west-2": {
-                "AMI": "ami-2a31bf1a"
+                "AMI": "ami-0358ce33"
             },
             "eu-west-1": {
-                "AMI": "ami-c37474b7"
+                "AMI": "ami-c7c0d6b3"
             },
             "ap-southeast-1": {
-                "AMI": "ami-a6a7e7f4"
+                "AMI": "ami-fade91a8"
             },
             "ap-northeast-1": {
-                "AMI": "ami-4e6cd34f"
+                "AMI": "ami-39b23d38"
             },
             "sa-east-1": {
-                "AMI": "ami-1e08d103"
+                "AMI": "ami-5253894f"
             }
         }
     },

--- a/chef/cookbooks/asgard/recipes/default.rb
+++ b/chef/cookbooks/asgard/recipes/default.rb
@@ -41,6 +41,7 @@ bash "enable security" do
   user "root"
   cwd "/usr/share/tomcat6/webapps/asgard/WEB-INF"
   code <<-EOH
+    cp web.xml web.xml.orig
     linecount=`wc -l web.xml | awk '{ print $1}'`
     i=`expr $linecount - 1`
     head -$i web.xml > /tmp/head

--- a/chef/data_bags/users/frans.json
+++ b/chef/data_bags/users/frans.json
@@ -1,0 +1,8 @@
+{
+  "id"        : "frans",
+  "comment"   : "Frans Bresler Slabber",
+  "groups"    : ["wheel"],
+  "ssh_keys"  : [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIJ0VE4XU91vrPrDIonKO36/YYYa2YBLnvrp+30zQrlTpp6yegHDMy8fkKVD7yIAkOBVywXb8/dacjZOs3Z9qLGxydwRgaoaZzxukPazdAZsouVhrgROs6jzf/uIspDpdQ1uIJsh0RzJ4SwPvT0ve/51+btPE30N9vzM3eJ+ooOn6yJqgRbjLYAm6sVib5/R83FqqYCTiYqS6nzjutgKZMw9eJs7cnNuMtajv5gHj6pbaH/oh20oVYj1DqV55qfBhFvBa3gFfllAXGnQIwy6dko2PxjtKEE2LBgVxsP1d4JkS2SJp3BbH4zgbKSJVATz1CxZ8dDxXJHhYKJAIcPdDD"
+                ]
+}
+

--- a/chef/data_bags/users/geoff.json
+++ b/chef/data_bags/users/geoff.json
@@ -1,0 +1,8 @@
+{
+  "id"        : "geoff",
+  "comment"   : "Geoff Catlin",
+  "groups"    : ["wheel"],
+  "ssh_keys"  : [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIJ0VE4XU91vrPrDIonKO36/YYYa2YBLnvrp+30zQrlTpp6yegHDMy8fkKVD7yIAkOBVywXb8/dacjZOs3Z9qLGxydwRgaoaZzxukPazdAZsouVhrgROs6jzf/uIspDpdQ1uIJsh0RzJ4SwPvT0ve/51+btPE30N9vzM3eJ+ooOn6yJqgRbjLYAm6sVib5/R83FqqYCTiYqS6nzjutgKZMw9eJs7cnNuMtajv5gHj6pbaH/oh20oVYj1DqV55qfBhFvBa3gFfllAXGnQIwy6dko2PxjtKEE2LBgVxsP1d4JkS2SJp3BbH4zgbKSJVATz1CxZ8dDxXJHhYKJAIcPdDD"
+                ]
+}
+

--- a/chef/data_bags/users/james.json
+++ b/chef/data_bags/users/james.json
@@ -1,0 +1,8 @@
+{
+  "id"        : "james",
+  "comment"   : "James Van Dyke",
+  "groups"    : ["wheel"],
+  "ssh_keys"  : [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIJ0VE4XU91vrPrDIonKO36/YYYa2YBLnvrp+30zQrlTpp6yegHDMy8fkKVD7yIAkOBVywXb8/dacjZOs3Z9qLGxydwRgaoaZzxukPazdAZsouVhrgROs6jzf/uIspDpdQ1uIJsh0RzJ4SwPvT0ve/51+btPE30N9vzM3eJ+ooOn6yJqgRbjLYAm6sVib5/R83FqqYCTiYqS6nzjutgKZMw9eJs7cnNuMtajv5gHj6pbaH/oh20oVYj1DqV55qfBhFvBa3gFfllAXGnQIwy6dko2PxjtKEE2LBgVxsP1d4JkS2SJp3BbH4zgbKSJVATz1CxZ8dDxXJHhYKJAIcPdDD"
+                ]
+}
+

--- a/chef/data_bags/users/jarrett.json
+++ b/chef/data_bags/users/jarrett.json
@@ -1,0 +1,8 @@
+{
+  "id"        : "jarrett",
+  "comment"   : "Jarrett Jordan",
+  "groups"    : ["wheel"],
+  "ssh_keys"  : [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIJ0VE4XU91vrPrDIonKO36/YYYa2YBLnvrp+30zQrlTpp6yegHDMy8fkKVD7yIAkOBVywXb8/dacjZOs3Z9qLGxydwRgaoaZzxukPazdAZsouVhrgROs6jzf/uIspDpdQ1uIJsh0RzJ4SwPvT0ve/51+btPE30N9vzM3eJ+ooOn6yJqgRbjLYAm6sVib5/R83FqqYCTiYqS6nzjutgKZMw9eJs7cnNuMtajv5gHj6pbaH/oh20oVYj1DqV55qfBhFvBa3gFfllAXGnQIwy6dko2PxjtKEE2LBgVxsP1d4JkS2SJp3BbH4zgbKSJVATz1CxZ8dDxXJHhYKJAIcPdDD"
+                ]
+}
+

--- a/chef/data_bags/users/mark.json
+++ b/chef/data_bags/users/mark.json
@@ -1,0 +1,8 @@
+{
+  "id"        : "mark",
+  "comment"   : "Mark Merrill",
+  "groups"    : ["wheel"],
+  "ssh_keys"  : [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIJ0VE4XU91vrPrDIonKO36/YYYa2YBLnvrp+30zQrlTpp6yegHDMy8fkKVD7yIAkOBVywXb8/dacjZOs3Z9qLGxydwRgaoaZzxukPazdAZsouVhrgROs6jzf/uIspDpdQ1uIJsh0RzJ4SwPvT0ve/51+btPE30N9vzM3eJ+ooOn6yJqgRbjLYAm6sVib5/R83FqqYCTiYqS6nzjutgKZMw9eJs7cnNuMtajv5gHj6pbaH/oh20oVYj1DqV55qfBhFvBa3gFfllAXGnQIwy6dko2PxjtKEE2LBgVxsP1d4JkS2SJp3BbH4zgbKSJVATz1CxZ8dDxXJHhYKJAIcPdDD"
+                ]
+}
+

--- a/chef/data_bags/users/megan.json
+++ b/chef/data_bags/users/megan.json
@@ -1,0 +1,8 @@
+{
+  "id"        : "megan",
+  "comment"   : "Megan Watson",
+  "groups"    : ["wheel"],
+  "ssh_keys"  : [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIJ0VE4XU91vrPrDIonKO36/YYYa2YBLnvrp+30zQrlTpp6yegHDMy8fkKVD7yIAkOBVywXb8/dacjZOs3Z9qLGxydwRgaoaZzxukPazdAZsouVhrgROs6jzf/uIspDpdQ1uIJsh0RzJ4SwPvT0ve/51+btPE30N9vzM3eJ+ooOn6yJqgRbjLYAm6sVib5/R83FqqYCTiYqS6nzjutgKZMw9eJs7cnNuMtajv5gHj6pbaH/oh20oVYj1DqV55qfBhFvBa3gFfllAXGnQIwy6dko2PxjtKEE2LBgVxsP1d4JkS2SJp3BbH4zgbKSJVATz1CxZ8dDxXJHhYKJAIcPdDD"
+                ]
+}
+

--- a/chef/data_bags/users/paul.json
+++ b/chef/data_bags/users/paul.json
@@ -1,0 +1,8 @@
+{
+  "id"        : "paul",
+  "comment"   : "Paul Barrett",
+  "groups"    : ["wheel"],
+  "ssh_keys"  : [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIJ0VE4XU91vrPrDIonKO36/YYYa2YBLnvrp+30zQrlTpp6yegHDMy8fkKVD7yIAkOBVywXb8/dacjZOs3Z9qLGxydwRgaoaZzxukPazdAZsouVhrgROs6jzf/uIspDpdQ1uIJsh0RzJ4SwPvT0ve/51+btPE30N9vzM3eJ+ooOn6yJqgRbjLYAm6sVib5/R83FqqYCTiYqS6nzjutgKZMw9eJs7cnNuMtajv5gHj6pbaH/oh20oVYj1DqV55qfBhFvBa3gFfllAXGnQIwy6dko2PxjtKEE2LBgVxsP1d4JkS2SJp3BbH4zgbKSJVATz1CxZ8dDxXJHhYKJAIcPdDD"
+                ]
+}
+

--- a/chef/data_bags/users/peter.json
+++ b/chef/data_bags/users/peter.json
@@ -1,0 +1,8 @@
+{
+  "id"        : "peter",
+  "comment"   : "Peter Garbers",
+  "groups"    : ["wheel"],
+  "ssh_keys"  : [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIJ0VE4XU91vrPrDIonKO36/YYYa2YBLnvrp+30zQrlTpp6yegHDMy8fkKVD7yIAkOBVywXb8/dacjZOs3Z9qLGxydwRgaoaZzxukPazdAZsouVhrgROs6jzf/uIspDpdQ1uIJsh0RzJ4SwPvT0ve/51+btPE30N9vzM3eJ+ooOn6yJqgRbjLYAm6sVib5/R83FqqYCTiYqS6nzjutgKZMw9eJs7cnNuMtajv5gHj6pbaH/oh20oVYj1DqV55qfBhFvBa3gFfllAXGnQIwy6dko2PxjtKEE2LBgVxsP1d4JkS2SJp3BbH4zgbKSJVATz1CxZ8dDxXJHhYKJAIcPdDD"
+                ]
+}
+

--- a/chef/data_bags/users/rchekaluk.json
+++ b/chef/data_bags/users/rchekaluk.json
@@ -1,0 +1,10 @@
+{
+  "id"        : "rchekaluk",
+  "comment"   : "Rob Chekaluk",
+  "groups"    : ["wheel"],
+  "ssh_keys"  : [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIJ0VE4XU91vrPrDIonKO36/YYYa2YBLnvrp+30zQrlTpp6yegHDMy8fkKVD7yIAkOBVywXb8/dacjZOs3Z9qLGxydwRgaoaZzxukPazdAZsouVhrgROs6jzf/uIspDpdQ1uIJsh0RzJ4SwPvT0ve/51+btPE30N9vzM3eJ+ooOn6yJqgRbjLYAm6sVib5/R83FqqYCTiYqS6nzjutgKZMw9eJs7cnNuMtajv5gHj6pbaH/oh20oVYj1DqV55qfBhFvBa3gFfllAXGnQIwy6dko2PxjtKEE2LBgVxsP1d4JkS2SJp3BbH4zgbKSJVATz1CxZ8dDxXJHhYKJAIcPdDD",
+
+                  "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAwEOi31uBJ9KNdD8e2b1iXkDevN4xxcVihz9Fpk0lXz8Wu1Y8bQDs0nxycKq6JIOwqxzvCvSjhxLNZG08XYfLrEzf91Ry2JmreQSDGwYvFbYDuUmOhRZBf8GEcsP9f7vhsSsC7oWSbYxKcMYRo2/sPxO1rqo03V0qWpSmZMIGlMQWVHkKn9pZEIrenFIovnr9HTbYD6quwzcjPPeoZBdBPTc1XPPTnJQ0KsX6D2gZWbG0S+uSTJKgwYaET0NEdlsS6mMemgfzIPpOjJdFp+dsVEMVxd8gRLaBMfStMwklSaa10ot02NuZAZtWwOFyIa5s2WRykDrWc2snYrn1RHy8xw== rob@linux-kew1"
+                ]
+}
+

--- a/solo.rb
+++ b/solo.rb
@@ -1,2 +1,3 @@
 file_cache_path "/home/ec2-user/asgard-in-the-cloud/chef/"
 cookbook_path "/home/ec2-user/asgard-in-the-cloud/chef/cookbooks"
+data_bag_path "/home/ec2-user/asgard-in-the-cloud/chef/data_bags"

--- a/solo.source
+++ b/solo.source
@@ -5,7 +5,20 @@
 
 },
 
+  "users": [ "frans",
+             "geoff",
+             "james",
+             "jarrett",
+             "mark",
+             "megan",
+             "paul",
+             "peter",
+             "rchekaluk"
+           ],
+
   "run_list": [ "recipe[tomcat6]",
+                "recipe[user]",
+                "recipe[user::data_bag]",
                 "recipe[sudoers]",
                 "recipe[asgard]"
                ]


### PR DESCRIPTION
Updates to the current Amazon Linux AMI IDs. Will also be happy to send a follow-on PR once the next AMIs are released (assuming that this will be soon).
